### PR TITLE
ci: run Trivy only on Dockerfile/requirements.txt changes and monthly schedule

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -8,11 +8,16 @@ name: trivy
 on:
   push:
     branches: [ "main" ]
+    paths:
+      - "Dockerfile"
+      - "requirements.txt"
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: [ "main" ]
+    paths:
+      - "Dockerfile"
+      - "requirements.txt"
   schedule:
-    - cron: '29 6 * * 1'
+    - cron: '29 6 1 * *'
 
 permissions:
   contents: read
@@ -27,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Build an image from Dockerfile
         run: |


### PR DESCRIPTION
## Changes

- **Path filter**: Trivy only runs on push/PR when Dockerfile or requirements.txt change
- **Monthly schedule**: Changed from weekly (Monday) to 1st of every month
- **Bumped** actions/checkout to v5

## Why

Trivy scans Docker images which is slow and uses CI minutes. Since image contents only change when the Dockerfile or dependencies change, running on every push is wasteful. Monthly schedule catches newly disclosed vulnerabilities in existing dependencies.